### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@
 
 If you are a git user, you can install the theme and keep up to date by cloning the repo:
 
-    $ git clone https://github.com/dracula/obsidian.git
+    $ git clone https://github.com/dracula/obsidian.git themes
 
 #### Install manually
 
@@ -12,7 +12,6 @@ Download using the [GitHub .zip download](https://github.com/dracula/obsidian/ar
 
 #### Activating theme
 
-1. Clone the project to `.obsidian/themes` directory.
-2. Move file `.obsidian/themes/obsidian/obsidian.css` to `.obsidian/themes/obsidian.css`.
-3. Choose your downloaded theme `Settings > Themes > Theme` at Obsidian tool. It should take effect immediately.
-4. Boom! It's working.
+1. Clone the project to `.obsidian/themes` directly. If you already have `themes` folder, delete it before clone.
+2. Choose your downloaded theme `Settings > Themes > Theme` at Obsidian tool. It should take effect immediately.
+3. Boom! It's working.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,6 +12,7 @@ Download using the [GitHub .zip download](https://github.com/dracula/obsidian/ar
 
 #### Activating theme
 
-1. Turn on 'Custom CSS' plugin in Obsidian: `Settings > Plugins > Custom CSS.`
-2. Download and copy the `obsidian.css` file to the root folder of your Obsidian vault. It should take effect immediately.
-3. Boom! It's working
+1. Clone the project to `.obsidian/themes` directory.
+2. Move file `.obsidian/themes/obsidian/obsidian.css` to `.obsidian/themes/obsidian.css`.
+3. Choose your downloaded theme `Settings > Themes > Theme` at Obsidian tool. It should take effect immediately.
+4. Boom! It's working.


### PR DESCRIPTION
It gives more details about how to enable the custom theme to Obsidian.

The current configuration at Obsidian looks like this:
<img width="1342" alt="Screenshot 2021-03-06 at 10 21 22" src="https://user-images.githubusercontent.com/862575/110203365-bcd7fb80-7e65-11eb-9d8b-7c21b05dc4a3.png">

IMO, the current configuration `INSTALL.md` shows a not clear way to do the installation of the theme.