### PR TITLE
Contrast/visualization correction of table borders

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -429,15 +429,20 @@ img {
 
 th {
   font-weight: 800 !important;
+  border: 1px solid var(--background-primary-alt) !important;
+}
+
+td {
+  border: 1px solid var(--background-primary-alt) !important
 }
 
 thead {
-  border-bottom: 4px solid var(--background-modifier-border);
+  border-bottom: 4px solid var(--background-primary-alt);
 }
 
 .table {
   background-color: var(--background-secondary-alt);
-  border: 1px solid var(--background-modifier-border);
+  border: 1px solid var(--background-primary-alt);
   padding: 4px;
   line-height: normal;
   display: block;


### PR DESCRIPTION
Updated th and .table color border
Added td color border
![print](https://user-images.githubusercontent.com/50890356/117072281-94a23700-ad06-11eb-90e3-cade645ec6ff.png)

> If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.