### PR TITLE
Fixes sidebar styling in translucent mode

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -356,7 +356,7 @@ button.mod-cta {
   background-color: var(--background-secondary);
 }
 
-.is-translucent .nav-file-title {
+.is-translucent .nav-file-title:not(.is-active) {
   background-color: transparent;
 }
 

--- a/obsidian.css
+++ b/obsidian.css
@@ -356,9 +356,17 @@ button.mod-cta {
   background-color: var(--background-secondary);
 }
 
+.is-translucent .nav-file-title {
+  background-color: transparent;
+}
+
 .nav-folder-title {
   color: var(--text-muted) !important;
   background-color: var(--background-secondary);
+}
+
+.is-translucent .nav-folder-title {
+  background-color: transparent;
 }
 
 .nav-file-title:hover {

--- a/obsidian.css
+++ b/obsidian.css
@@ -386,6 +386,10 @@ button.mod-cta {
   background-color: var(--background-secondary);
 }
 
+.is-translucent .search-result-file-title {
+  background-color: transparent;
+}
+
 .search-result-file-matched-text {
   color: var(--text-link) !important;
   background-color: var(--background-secondary);

--- a/obsidian.css
+++ b/obsidian.css
@@ -356,17 +356,9 @@ button.mod-cta {
   background-color: var(--background-secondary);
 }
 
-.is-translucent .nav-file-title:not(.is-active) {
-  background-color: transparent;
-}
-
 .nav-folder-title {
   color: var(--text-muted) !important;
   background-color: var(--background-secondary);
-}
-
-.is-translucent .nav-folder-title {
-  background-color: transparent;
 }
 
 .nav-file-title:hover {
@@ -384,10 +376,6 @@ button.mod-cta {
 .search-result-file-title {
   color: var(--text-a) !important;
   background-color: var(--background-secondary);
-}
-
-.is-translucent .search-result-file-title {
-  background-color: transparent;
 }
 
 .search-result-file-matched-text {

--- a/theme.css
+++ b/theme.css
@@ -364,7 +364,7 @@ button.mod-cta {
   background-color: var(--background-secondary);
 }
 
-.is-translucent .nav-file-title {
+.is-translucent .nav-file-title:not(.is-active) {
   background-color: transparent;
 }
 

--- a/theme.css
+++ b/theme.css
@@ -364,9 +364,17 @@ button.mod-cta {
   background-color: var(--background-secondary);
 }
 
+.is-translucent .nav-file-title {
+  background-color: transparent;
+}
+
 .nav-folder-title {
   color: var(--text-muted) !important;
   background-color: var(--background-secondary);
+}
+
+.is-translucent .nav-folder-title {
+  background-color: transparent;
 }
 
 .nav-file-title:hover {

--- a/theme.css
+++ b/theme.css
@@ -394,6 +394,10 @@ button.mod-cta {
   background-color: var(--background-secondary);
 }
 
+.is-translucent .search-result-file-title {
+  background-color: transparent;
+}
+
 .search-result-file-matched-text {
   color: var(--text-link) !important;
   background-color: var(--background-secondary);


### PR DESCRIPTION
Nice work on this theme, it looks sharp! _However_ I noticed that the theme doesn't fully respect translucent mode. It's subtle, but the folder and file names have an opaque background in translucent mode. This PR removes that background for translucent mode. Normal mode is left untouched.

<img width="630" alt="A fix for translucent mode in the Dracula Obsidian theme." src="https://user-images.githubusercontent.com/963985/194390416-0477c56a-32b1-4d34-b4fe-816faa6bedae.png">

The problem was more noticeable in light mode, and this also fixes that (even though I know that vampires [don't like the light](https://github.com/dracula/dracula-theme/discussions/508))

<img width="549" alt="A fix for translucent mode in the light version of the Dracula Obsidian theme." src="https://user-images.githubusercontent.com/963985/194389851-d1cfafa7-4e37-4f2d-8b05-934fd91744ee.png">

