### PR TITLE
fix: mark inline color styles

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -563,8 +563,8 @@ em {
 /* preview */
 
 mark {
-  color: var(--background-primary) !important;
-  background-color: var(--text-mark) !important;
+  color: var(--background-primary);
+  background-color: var(--text-mark);
   padding-top: 1px;
   padding-bottom: 1px;
 }


### PR DESCRIPTION
Fixed issue with Highlitr plugin: https://github.com/chetachiezikeuzor/Highlightr-Plugin/issues/56

Actual:
<img width="280" alt="CleanShot 2022-12-22 at 22 56 55@2x" src="https://user-images.githubusercontent.com/9741188/209232962-2c55efbc-049b-487b-816f-e535721dab6d.png">

Expected:
<img width="280" alt="CleanShot 2022-12-22 at 22 57 07@2x" src="https://user-images.githubusercontent.com/9741188/209232976-78336bf4-de0d-43b5-8b78-86f2db428ab1.png">
