### PR TITLE
Update theme.css

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -754,4 +754,10 @@ ol {
       background-color: #282a36; 
       color: #f8f8f2;
   }
+  pre,
+  code span,
+  code {
+      color: #5a5a5a !important;
+      background-color: #fafafa !important;
+  }
 }


### PR DESCRIPTION
This will solve the inline code blocks issue being white text over white background when printing in PDF. Fixes #34.

This is the .md note I am using as PoC.

![image](https://github.com/dracula/obsidian/assets/57040859/63176a40-6e1a-47e9-8a29-a0a17047000d)

This is before the pull I am suggesting.

![image](https://github.com/dracula/obsidian/assets/57040859/0e02d671-a23c-4020-b749-0f49f4586467)

This is after.

![image](https://github.com/dracula/obsidian/assets/57040859/8f6cfcf6-5b24-4efa-b9a1-3f0f31595213)
