### PR TITLE
Fix to use comment color 

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -264,6 +264,10 @@ pre code {
   color: var(--dracula-string);
 }
 
+.cm-hmd-codeblock.cm-comment {
+  color: var(--dracula-Comment);
+}
+
 /* Preview */
 
 code {


### PR DESCRIPTION
  Use the variable `--dracula-Comment: #6272A4;` for comments

### Before
<img width="408" height="109" alt="image" src="https://github.com/user-attachments/assets/6bffb39a-1506-473a-b2b1-b1f81173011a" />

### After
<img width="401" height="82" alt="image" src="https://github.com/user-attachments/assets/c5950cad-c00a-4088-8778-e5bd9f5c29a7" />
