### PR TITLE
Fix #56 - Make text light instead of dark when selected in settings sidebar

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -431,7 +431,7 @@ button.mod-cta {
 
 .horizontal-tab-nav-item.is-active, .vertical-tab-nav-item.is-active {
   background-color: var(--interactive-accent);
-  color: var(--text-on-accent);
+  color: var(--text-normal);
 }
 
 /* searchbar */


### PR DESCRIPTION
Closes #56.

How it was (stolen from #56):

<img width="1024" height="800" alt="image" src="https://github.com/user-attachments/assets/5d040ed3-337f-4954-b0cd-fd5520d63a0f" />

How it became:

<img width="1900" height="1104" alt="image" src="https://github.com/user-attachments/assets/0f5ca7f2-9564-4121-83bb-b463e8bb0eb5" />
